### PR TITLE
Improve support for @glimmer/validator dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,8 @@ workspace:
 
 ## Installation
 
-* `git clone https://github.com/tracked-tools/tracked-built-ins.git`
-* `cd tracked-built-ins`
+* `git clone https://github.com/ember-migration-utils/tracked-built-ins-compat.git`
+* `cd tracked-built-ins-compat`
 * `pnpm install`
 
 ## Linting

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Installation
 ------------------------------------------------------------------------------
 
 ```
-ember install tracked-built-ins
+ember install @ember-compat/tracked-built-ins
 ```
 
 Usage

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ This Ember addon is based on the
 [tracked-built-ins](https://github.com/tracked-tools/tracked-built-ins) addon.
 It has been extended to include extra interop support for classic Ember.
 
+**Note:** If you are experiencing issues related to the `@glimmer/validator`
+dependency, verify that you're using either `embroider` or `ember-auto-import`
+>= v2.4.3 in your host app to ensure that it is properly treated as an external.
+
 ---
 
 This addon provides tracked versions of JavaScript's built-ins:

--- a/addon/.npmignore
+++ b/addon/.npmignore
@@ -2,6 +2,7 @@
 /dist/
 
 # misc
+/node_modules/
 /.eslintcache
 /.eslintignore
 /.eslintrc.js

--- a/addon/package.json
+++ b/addon/package.json
@@ -85,6 +85,9 @@
     "main": "addon-main.js",
     "type": "addon",
     "version": 2,
-    "app-js": {}
+    "app-js": {},
+    "externals": [
+      "@glimmer/validator"
+    ]
   }
 }

--- a/addon/src/-private/property-storage-map.ts
+++ b/addon/src/-private/property-storage-map.ts
@@ -1,4 +1,4 @@
-import { consumeTag, tagFor, dirtyTagFor } from '@glimmer/validator';
+import { consumeProperty, dirtyProperty } from './validator-versions';
 
 export class PropertyStorageMap {
   readonly #object: object;
@@ -8,10 +8,10 @@ export class PropertyStorageMap {
   }
 
   consume(key: string | symbol) {
-    consumeTag(tagFor(this.#object, key as string | symbol));
+    consumeProperty(this.#object, key);
   }
 
   update(key: string | symbol) {
-    dirtyTagFor(this.#object, key as string | symbol);
+    dirtyProperty(this.#object, key);
   }
 }

--- a/addon/src/-private/validator-versions.ts
+++ b/addon/src/-private/validator-versions.ts
@@ -1,0 +1,58 @@
+import * as validator from '@glimmer/validator';
+
+type Tag = object;
+
+// v0.84
+interface V84 {
+  consumeTag: (tag: Tag) => void;
+  tagFor: (object: object, property: PropertyKey) => Tag;
+  dirtyTagFor: (object: object, property: PropertyKey) => void;
+}
+
+// v0.44
+interface V44 {
+  consume: (tag: Tag) => void;
+  tagFor: (object: object, property: PropertyKey) => Tag;
+  dirty: (tag: Tag) => void;
+}
+
+type ValidatorVersions = V84 | V44;
+
+function isV84(validator: ValidatorVersions): validator is V84 {
+  return (
+    'consumeTag' in validator &&
+    typeof validator.consumeTag === 'function' &&
+    'tagFor' in validator &&
+    typeof validator.tagFor === 'function' &&
+    'dirtyTagFor' in validator &&
+    typeof validator.dirtyTagFor === 'function'
+  );
+}
+
+interface Validator {
+  dirtyProperty: (object: object, property: PropertyKey) => void;
+  consumeProperty: (object: object, property: PropertyKey) => void;
+}
+
+function normalize(module: ValidatorVersions): Validator {
+  if (isV84(module)) {
+    return {
+      dirtyProperty: (object: object, property: PropertyKey) => {
+        module.dirtyTagFor(object, property);
+      },
+      consumeProperty: (object: object, property: PropertyKey) => {
+        module.consumeTag(module.tagFor(object, property));
+      },
+    };
+  } else {
+    throw new Error(
+      'The version of @glimmer/validator included with this build is incompatible with @ember-compat/tracked-built-ins. '
+    );
+  }
+}
+
+const { dirtyProperty, consumeProperty } = normalize(
+  validator as ValidatorVersions
+);
+
+export { dirtyProperty, consumeProperty };

--- a/package.json
+++ b/package.json
@@ -37,9 +37,6 @@
           "addon"
         ],
         "additionalManifests": {
-          "dependencyUpdates": [
-            "test-app/package.json"
-          ],
           "versionUpdates": [
             "test-app/package.json"
           ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,7 +75,7 @@ importers:
 
   test-app:
     specifiers:
-      '@ember-compat/tracked-built-ins': 0.9.0
+      '@ember-compat/tracked-built-ins': workspace:*
       '@ember/optional-features': ^2.0.0
       '@ember/test-helpers': 2.8.1
       '@embroider/test-setup': ^1.8.3
@@ -93,7 +93,7 @@ importers:
       '@typescript-eslint/eslint-plugin': ^5.40.0
       '@typescript-eslint/parser': ^5.26.0
       broccoli-asset-rev: ^3.0.0
-      ember-auto-import: ^2.4.2
+      ember-auto-import: ^2.4.3
       ember-cli: ~4.3.0
       ember-cli-babel: ^7.26.11
       ember-cli-dependency-checker: ^3.3.1

--- a/test-app/app/components/person.js
+++ b/test-app/app/components/person.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 // import { tracked } from '@glimmer/tracking';
-import { TrackedMap } from 'tracked-built-ins';
+import { TrackedMap } from '@ember-compat/tracked-built-ins';
 
 export default class Person extends Component {
   friends = new TrackedMap();

--- a/test-app/ember-cli-build.js
+++ b/test-app/ember-cli-build.js
@@ -7,13 +7,7 @@ module.exports = function (defaults) {
     autoImport: {
       forbidEval: true,
       watchDependencies: ['@ember-compat/tracked-built-ins'],
-      webpack: {
-        externals: {
-          '@glimmer/validator': 'commonjs @glimmer/validator',
-        },
-      },
     },
-    // Add options here
   });
 
   const { maybeEmbroider } = require('@embroider/test-setup');

--- a/test-app/ember-cli-build.js
+++ b/test-app/ember-cli-build.js
@@ -6,7 +6,7 @@ module.exports = function (defaults) {
   let app = new EmberApp(defaults, {
     autoImport: {
       forbidEval: true,
-      watchDependencies: ['tracked-built-ins'],
+      watchDependencies: ['@ember-compat/tracked-built-ins'],
       webpack: {
         externals: {
           '@glimmer/validator': 'commonjs @glimmer/validator',

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -44,7 +44,7 @@
     "@typescript-eslint/eslint-plugin": "^5.40.0",
     "@typescript-eslint/parser": "^5.26.0",
     "broccoli-asset-rev": "^3.0.0",
-    "ember-auto-import": "^2.4.2",
+    "ember-auto-import": "^2.4.3",
     "ember-cli": "~4.3.0",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-dependency-checker": "^3.3.1",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "2.8.1",
-    "@ember-compat/tracked-built-ins": "0.9.0",
+    "@ember-compat/tracked-built-ins": "workspace:*",
     "@embroider/test-setup": "^1.8.3",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",


### PR DESCRIPTION
Marks `@glimmer/validator` as an external in the addon's package.json. This should be respected by ember-auto-import >= 2.4.3 as well as recent versions of embroider.

Also adds dynamic version checking of `@glimmer/validator` to provide a custom error message if the version of the package is not supported.